### PR TITLE
fix para el start_job

### DIFF
--- a/src/HeadlessChromeDriver.ts
+++ b/src/HeadlessChromeDriver.ts
@@ -53,14 +53,14 @@ export class HeadlessChromeDriver extends EventEmitter implements IHeadlessChrom
     }
 
     public startJob(jobId: number) {
-        
+
         if (this.jobTimeout != null) {
             const errMsg = "cannot start a new job until the previous has finished"
             logger.error(errMsg);
             throw new Error(errMsg);
         }
-        
-        this.currentJob =  new Job(jobId);
+
+        this.currentJob = new Job(jobId);
         this.jobsCount++
         logger.job_start(this.currentJobLog())
         this.jobTimeout = setTimeout(() => {
@@ -73,14 +73,14 @@ export class HeadlessChromeDriver extends EventEmitter implements IHeadlessChrom
     }
 
     public endJob(url = null) {
-        this.clearJobTimeout();
         logger.job_end(this.currentJobLog(), url)
-        this.emit("job_end", this)
-
+        this.currentJob = null;
+        this.clearJobTimeout();
+        this.emit("job_end", this);
         return this.currentJob;
     }
 
-    public getCurrentJob(){
+    public getCurrentJob() {
         return this.currentJob;
     }
 

--- a/src/Job.ts
+++ b/src/Job.ts
@@ -1,0 +1,14 @@
+export interface IJob {
+    readonly jobId: number;
+    jobLog(): string;
+}
+
+export class Job implements IJob {
+    constructor(readonly jobId: number) {
+
+    }
+
+    jobLog(): string {
+        return ` [JOB: ${this.jobId}]`
+    }
+}

--- a/test/HeadlessChromeDriver.spec.ts
+++ b/test/HeadlessChromeDriver.spec.ts
@@ -59,5 +59,13 @@ describe("HeadlessChromeDriver", () => {
         const driver = new HeadlessChromeDriverFactory().createInstance()
 
         expect(driver.jobsTimeout).toBe(parseInt(timeout) * 1000);
-    })
+    });
+
+    it("jobsTimeout should be set to the defined value", () => {
+        const driver = new HeadlessChromeDriverFactory().createInstance()
+
+        var job = driver.startJob(1);
+        expect(() => driver.startJob(2)).toThrowError();
+        expect(driver.getCurrentJob()).toBe(job);
+    });
 })

--- a/test/HeadlessChromeServer.spec.ts
+++ b/test/HeadlessChromeServer.spec.ts
@@ -11,6 +11,7 @@ import { IHttpProxy } from "../src/HttpProxy";
 import { IHttpServerFactory } from "../src/HttpServerFactory";
 import { IHttpServer } from "../src/HttpServer";
 import { logger } from "../src/Logger";
+import { Job } from "../src/Job";
 
 const idGenerator: IdGenerator = new IdGenerator();
 
@@ -26,21 +27,27 @@ class MockHeadlessChromeDriver extends EventEmitter implements IHeadlessChromeDr
         this.wsEndpoint = "ws://localhost:30000/";
         this.jobsLimit = 30;
         this.jobsTimeout = 30000;
-    }    
-    jobsLimit:number;
-    jobsTimeout:number;    
+    }
+    jobsLimit: number;
+    jobsTimeout: number;
     defaultJobLimit = 30;
     defaultJobTimeout = 30;
+    currentJob = new Job(1);
 
     jobLimitExceeded(): boolean {
         return false;
     }
 
     startJob() {
+        return this.currentJob;
     }
 
     endJob() {
+        return this.currentJob;
+    }
 
+    getCurrentJob() {
+        return this.currentJob;
     }
 
     async launch(): Promise<IHeadlessChromeDriver> {
@@ -115,11 +122,11 @@ describe("HeadlessChromeServer", () => {
         td.when(factoryProxyMock.createInstance()).thenReturn<IHttpProxy>(httpProxyMock);
         td.when(factoryServerMock.createInstance()).thenReturn<IHttpServer>(httpServerMock);
         td.when(factoryDriverMock.createInstance()).thenReturn<IHeadlessChromeDriver>(...drivers);
-    
+
         delete process.env.POOL_SIZE;
     });
 
-    beforeAll(()=>{
+    beforeAll(() => {
         logger.disable();
     });
 


### PR DESCRIPTION
Se arregla el start_job para que no se guarde la referencia al nuevo job antes de chequear si termino el anterior