### PR TITLE
Fix log y job end

### DIFF
--- a/src/HeadlessChromeDriver.ts
+++ b/src/HeadlessChromeDriver.ts
@@ -77,13 +77,16 @@ export class HeadlessChromeDriver extends EventEmitter implements IHeadlessChrom
         logger.job_end(this.currentJobLog(), url)
         this.currentJob = null;
         this.clearJobTimeout();
-        this.emit("job_end", this);
 
         if (this.jobLimitExceeded()) {
-            logger.warn(`${this.currentIdLog()} job limit exceeded`)
+            logger.job_limit_exceeded(this.currentIdLog())
             this.emit("job_limit_exceeded", this);
         }
+        else {
 
+            this.emit("job_end", this);
+
+        }
         return job;
     }
 
@@ -142,8 +145,8 @@ export class HeadlessChromeDriver extends EventEmitter implements IHeadlessChrom
         try {
             this.clearJobTimeout();
             this.browser.removeAllListeners()
-            await this.browser.close()
-            this.process.kill();
+            try{await this.browser.close()} catch {}
+            this.process.kill("SIGTERM");
         } catch (e) {
             logger.error("issue killing browser", e)
         }
@@ -172,7 +175,7 @@ export class HeadlessChromeDriver extends EventEmitter implements IHeadlessChrom
         return `[CHROME: ${this.id}]`.padEnd(8, ' ');
     }
     currentJobLog() {
-        return `${this.currentIdLog()}` + (this.jobsCount ? ` ${this.currentJob.jobLog()}` : '')
+        return `${this.currentIdLog()}` + (this.currentJob ? ` ${this.currentJob.jobLog()}` : '')
     }
     currentBrowserLog() {
         return `${this.currentIdLog()}` + ` [PID: ${this.browser.process().pid}]`.padEnd(13, ' ') + ` [URL: ${this.wsEndpoint}]`

--- a/src/HeadlessChromeServer.ts
+++ b/src/HeadlessChromeServer.ts
@@ -34,8 +34,7 @@ export class HeadLessChromeServer {
         process.on('uncaughtException', function (err) {
             console.error(err.stack);
         });
-
-        process.setMaxListeners(this.poolSize + 3);
+        
         process.once("exit", this.killBrowsers.bind(this));
     }
 
@@ -56,6 +55,7 @@ export class HeadLessChromeServer {
     }
 
     private async createInstance() {
+        process.setMaxListeners(process.getMaxListeners() + 3);
         let instance = this.headlessChromeDriverFactory.createInstance();
         this.setupInstance(instance);
         await instance.launch();

--- a/src/Logger.ts
+++ b/src/Logger.ts
@@ -60,7 +60,7 @@ interface LoggerOps {
     job_timeout(...msg)
     job_end(...msg)
     chrome_clear(...msg)
-    chrome_restart(...msg)
+    job_limit_exceeded(...msg)
 
     disable(); 
 }

--- a/src/Logger.ts
+++ b/src/Logger.ts
@@ -32,16 +32,16 @@ const options: any = {
             label: 'job_timeout',
             logLevel: 'debug'
         },
-        chrome_clear: {
-            badge: figures.pointer,
-            color: 'yellow',
-            label: 'chrome_clear',
+        job_limit_exceeded: {
+            badge: figures.warning,
+            color: 'magenta',
+            label: 'job_limit_exceeded',
             logLevel: 'debug'
         },
-        chrome_restart: {
-            badge: figures.pointerSmall,
+        chrome_clear: {
+            badge: figures.line,
             color: 'yellow',
-            label: 'chrome_restart',
+            label: 'chrome_clear',
             logLevel: 'debug'
         },
         nav: {

--- a/test/HeadlessChromeServer.spec.ts
+++ b/test/HeadlessChromeServer.spec.ts
@@ -146,10 +146,11 @@ describe("HeadlessChromeServer", () => {
         expect(_.get(headlessChromeServer.httpProxy, "options").ws).toBeTruthy();
     });
 
-    it("process.maxListeners should be greater than poolsize", () => {
+    it("process.maxListeners should be greater than poolsize", async () => {
         const headlessChromeServer = new HeadLessChromeServer(factoryDriverMock, factoryProxyMock, factoryServerMock);
+        await headlessChromeServer.start()
 
-        expect(process.getMaxListeners()).toBe(headlessChromeServer.poolSize + 3);
+        expect(process.getMaxListeners()).toBeGreaterThan(headlessChromeServer.poolSize *3);
     });
 
     it("idleBrowsers should be filled accordingly", async () => {


### PR DESCRIPTION
-fix: Se reutilizaba una instancia luego del job_limit  porque se estaba lanzando siempre el job_end
-fix: Una llamada al log intentaba acceder a la instancia de job luego de que había sido eliminada.
se agrega un logger custom para job_limit_exeeded y se borra el de chrome_restart
-el seteo de MaxEventListeners ahora se hace al crear cada instancia de chrome.

